### PR TITLE
Cross cut lupa

### DIFF
--- a/lukefi/metsi/forestry/cross_cutting/cross_cutting.py
+++ b/lukefi/metsi/forestry/cross_cutting/cross_cutting.py
@@ -13,7 +13,7 @@ _cross_cut_species_mapper = {
     TreeSpecies.SILVER_BIRCH: "birch"
 }
 
-ZERO_DIAMETER_DEFAULTS = ([3], [0.000045], [20])
+ZERO_DIAMETER_DEFAULTS = ([3], [0.000045], [20])  # energy wood, m3, €/m3; values from Reijo Mykkänen
 CrossCutFn = Callable[..., tuple[Sequence[int], Sequence[float], Sequence[float]]]
 
 
@@ -43,7 +43,7 @@ def apteeraus_Nasberg(T: np.ndarray, P: np.ndarray, m: int, n: int, div: int) ->
             if t < n:
                 d_top = T[t,0]
                 d_min = P[j, 1]
-                
+
                 if d_top >= d_min:
                     v = T[t,2] - T[i,2]
                     c = v * P[j, 3]
@@ -55,7 +55,7 @@ def apteeraus_Nasberg(T: np.ndarray, P: np.ndarray, m: int, n: int, div: int) ->
                         C[t] = c_tot
                         A[t] = P[j, 0]
                         L[t] = i
-                    
+
     maxi = np.argmax(C)
 
     nas = np.unique(P[:, 0])
@@ -93,7 +93,7 @@ def cross_cut_py(timber_price_table, div = 10) -> CrossCutFn:
 def cross_cut(
         species: TreeSpecies,
         breast_height_diameter: float,
-        height: float, 
+        height: float,
         timber_price_table,
         div=10,
         impl: str = "py"

--- a/lukefi/metsi/forestry/cross_cutting/cross_cutting.py
+++ b/lukefi/metsi/forestry/cross_cutting/cross_cutting.py
@@ -94,7 +94,7 @@ def cross_cut(
         species: TreeSpecies,
         breast_height_diameter: float,
         height: float,
-        timber_price_table,
+        P: np.ndarray,
         div=10,
         impl: str = "py"
         ) -> tuple[Sequence[int], Sequence[float], Sequence[float]]:
@@ -108,9 +108,9 @@ def cross_cut(
     if breast_height_diameter in (None, 0):
         return ZERO_DIAMETER_DEFAULTS
     if impl in ("fhk", "lua"):
-        cc = cross_cut_fhk(timber_price_table)
+        cc = cross_cut_fhk(tuple(P[:, 0]), tuple(P[:, 1]), tuple(P[:, 2]), tuple(P[:, 3]), P.shape[0], div, tuple(np.unique(P[:, 0])))
     elif impl == "lupa":
-        cc = cross_cut_lupa(timber_price_table)
+        cc = cross_cut_lupa(tuple(P[:, 0]), tuple(P[:, 1]), tuple(P[:, 2]), tuple(P[:, 3]), P.shape[0], div, tuple(np.unique(P[:, 0])))
     else:
-        cc = cross_cut_py(timber_price_table, div)
+        cc = cross_cut_py(P, div)
     return cc(species, breast_height_diameter, height)

--- a/lukefi/metsi/forestry/cross_cutting/cross_cutting.py
+++ b/lukefi/metsi/forestry/cross_cutting/cross_cutting.py
@@ -1,7 +1,9 @@
+from typing import Callable, Sequence
 import numpy as np
 from lukefi.metsi.data.enums.internal import TreeSpecies
-
 from lukefi.metsi.forestry.cross_cutting import stem_profile
+from lukefi.metsi.forestry.cross_cutting.cross_cutting_fhk import cross_cut_fhk
+from lukefi.metsi.forestry.cross_cutting.cross_cutting_lupa import cross_cut_lupa
 
 _cross_cut_species_mapper = {
     TreeSpecies.PINE: "pine",
@@ -11,9 +13,8 @@ _cross_cut_species_mapper = {
     TreeSpecies.SILVER_BIRCH: "birch"
 }
 
-ZERO_DIAMETER_TREE_TIMBER_GRADE = 3 # = energy wood
-ZERO_DIAMETER_TREE_VOLUME = 0.000045 # m3
-ZERO_DIAMETER_TREE_VALUE = 20 #€/m3
+ZERO_DIAMETER_DEFAULTS = ([3], [0.000045], [20])
+CrossCutFn = Callable[..., tuple[Sequence[int], Sequence[float], Sequence[float]]]
 
 
 def apteeraus_Nasberg(T: np.ndarray, P: np.ndarray, m: int, n: int, div: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -75,23 +76,8 @@ def apteeraus_Nasberg(T: np.ndarray, P: np.ndarray, m: int, n: int, div: int) ->
     return (nas, volumes, values) #deviating from the R implementation a little bit by also returning `nas`, the list of unique timber grades.
 
 
-def cross_cut(
-        species: TreeSpecies,
-        breast_height_diameter: float,
-        height: float, 
-        timber_price_table,
-        div = 10
-        ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """
-    Returns a tuple containing unique timber grades and their respective volumes and values.
-    If :breast_height_diameter: is 0 or none, the Nasberg cross cutting algorithm can't be applied. 
-    In this case, returns hardcoded constants.
-    """
-    if breast_height_diameter is not None and breast_height_diameter < 0:
-        raise ValueError("breast_height_diameter must be a non-negative number")
-    if breast_height_diameter in (None, 0):
-        return (np.array([ZERO_DIAMETER_TREE_TIMBER_GRADE]), np.array([ZERO_DIAMETER_TREE_VOLUME]), np.array([ZERO_DIAMETER_TREE_VALUE]))
-    else:
+def cross_cut_py(timber_price_table, div = 10) -> CrossCutFn:
+    def cc(species: TreeSpecies, breast_height_diameter, height):
         species_string = _cross_cut_species_mapper.get(species, "birch") #birch is used as the default species in cross cutting
         #the original cross-cut scripts rely on the height being an integer, thus rounding.
         height = round(height)
@@ -101,3 +87,30 @@ def cross_cut(
         m = P.shape[0]
 
         return apteeraus_Nasberg(T, P, m, n, div)
+    return cc
+
+
+def cross_cut(
+        species: TreeSpecies,
+        breast_height_diameter: float,
+        height: float, 
+        timber_price_table,
+        div=10,
+        impl: str = "py"
+        ) -> tuple[Sequence[int], Sequence[float], Sequence[float]]:
+    """
+    Returns a tuple containing unique timber grades and their respective volumes and values.
+    If :breast_height_diameter: is 0 or none, the Nasberg cross-cutting algorithm can't be applied.
+    In this case, returns hardcoded constants.
+    """
+    if breast_height_diameter is not None and breast_height_diameter < 0:
+        raise ValueError("breast_height_diameter must be a non-negative number")
+    if breast_height_diameter in (None, 0):
+        return ZERO_DIAMETER_DEFAULTS
+    if impl in ("fhk", "lua"):
+        cc = cross_cut_fhk(timber_price_table)
+    elif impl == "lupa":
+        cc = cross_cut_lupa(timber_price_table)
+    else:
+        cc = cross_cut_py(timber_price_table, div)
+    return cc(species, breast_height_diameter, height)

--- a/lukefi/metsi/forestry/cross_cutting/cross_cutting_fhk.py
+++ b/lukefi/metsi/forestry/cross_cutting/cross_cutting_fhk.py
@@ -60,7 +60,7 @@ def queryclass(retnames: Iterable[str]) -> type:
         [(name, float, field(default=fhk.root(name))) for name in retnames]
     )
 
-def cross_cut_func(P: np.ndarray) -> CrossCutFn:
+def cross_cut_fhk(P: np.ndarray) -> CrossCutFn:
     nas = list(map(int, np.unique(P[:,0])))
     retnames = []
     for v in nas:

--- a/lukefi/metsi/forestry/cross_cutting/cross_cutting_fhk.py
+++ b/lukefi/metsi/forestry/cross_cutting/cross_cutting_fhk.py
@@ -40,7 +40,7 @@ def defineapt(graph: fhk.Graph, P: np.ndarray, retnames: Iterable[str], div: flo
             impl.Lua {{
                 "crosscut",
                 load = function(pkg)
-                    return pkg.aptfunc(
+                    return pkg.aptfunc_fhk(
                         {ltab(P[:,0])},
                         {ltab(P[:,1])},
                         {ltab(P[:,2])},

--- a/lukefi/metsi/forestry/cross_cutting/cross_cutting_lupa.py
+++ b/lukefi/metsi/forestry/cross_cutting/cross_cutting_lupa.py
@@ -1,0 +1,46 @@
+from typing import Callable, Sequence
+
+import lupa
+import numpy as np
+from lukefi.metsi.data.enums.internal import TreeSpecies
+
+from lukefi.metsi.forestry.cross_cutting.cross_cutting import ZERO_DIAMETER_TREE_TIMBER_GRADE, ZERO_DIAMETER_TREE_VOLUME, \
+    ZERO_DIAMETER_TREE_VALUE
+from pathlib import Path
+
+CrossCutFn = Callable[..., tuple[Sequence[int], Sequence[float], Sequence[float]]]
+
+def cross_cut_lupa(P: np.ndarray) -> CrossCutFn:
+    path = Path(__file__).parent.parent.resolve() / "lua" / "crosscut.lua"
+
+    with open(path, "r") as file:
+        script = file.read()
+
+    lua = lupa.LuaRuntime(unpack_returned_tuples=True)
+    fn = lua.execute(script)['aptfunc']
+    pcls = lua.table_from(P[:, 0])
+    ptop = lua.table_from(P[:, 1])
+    plen = lua.table_from(P[:, 2])
+    pval = lua.table_from(P[:, 3])
+    m = P.shape[0]
+    div = 10
+    nas = np.unique(P[:, 0])
+
+    aptfunc = fn(pcls, ptop, plen, pval, m, div, len(nas))
+
+    def cc(
+            spe: TreeSpecies,
+            d: float,
+            h: float
+    ):
+        if d is not None and d < 0:
+            raise ValueError("breast_height_diameter must be a non-negative number")
+        if d in (None, 0):
+            return (np.array([ZERO_DIAMETER_TREE_TIMBER_GRADE]), np.array([ZERO_DIAMETER_TREE_VOLUME]), np.array([ZERO_DIAMETER_TREE_VALUE]))
+        result = aptfunc(spe, d, h)
+        vol, val = [], []
+        for i in range(0, len(nas)*2, 2):
+            vol.append(result[i])
+            val.append(result[i+1])
+        return list(map(int, np.unique(P[:, 0]))), vol, val
+    return cc

--- a/lukefi/metsi/forestry/cross_cutting/cross_cutting_lupa.py
+++ b/lukefi/metsi/forestry/cross_cutting/cross_cutting_lupa.py
@@ -17,7 +17,7 @@ def cross_cut_lupa(P: np.ndarray) -> CrossCutFn:
         script = file.read()
 
     lua = lupa.LuaRuntime(unpack_returned_tuples=True)
-    fn = lua.execute(script)['aptfunc']
+    fn = lua.execute(script)['aptfunc_lupa']
     pcls = lua.table_from(P[:, 0])
     ptop = lua.table_from(P[:, 1])
     plen = lua.table_from(P[:, 2])
@@ -37,10 +37,7 @@ def cross_cut_lupa(P: np.ndarray) -> CrossCutFn:
             raise ValueError("breast_height_diameter must be a non-negative number")
         if d in (None, 0):
             return (np.array([ZERO_DIAMETER_TREE_TIMBER_GRADE]), np.array([ZERO_DIAMETER_TREE_VOLUME]), np.array([ZERO_DIAMETER_TREE_VALUE]))
-        result = aptfunc(spe, d, h)
-        vol, val = [], []
-        for i in range(0, len(nas)*2, 2):
-            vol.append(result[i])
-            val.append(result[i+1])
-        return list(map(int, np.unique(P[:, 0]))), vol, val
+
+        vol, val = aptfunc(spe, d, h)
+        return list(map(int, np.unique(P[:, 0]))), list(vol.values()), list(val.values())
     return cc

--- a/lukefi/metsi/forestry/cross_cutting/cross_cutting_lupa.py
+++ b/lukefi/metsi/forestry/cross_cutting/cross_cutting_lupa.py
@@ -33,6 +33,6 @@ def cross_cut_lupa(P: np.ndarray) -> CrossCutFn:
             d: float,
             h: float
     ):
-        vol, val = aptfunc(spe, d, h)
+        vol, val = aptfunc(spe, d, round(h))
         return list(map(int, np.unique(P[:, 0]))), list(vol.values()), list(val.values())
     return cc

--- a/lukefi/metsi/forestry/cross_cutting/cross_cutting_lupa.py
+++ b/lukefi/metsi/forestry/cross_cutting/cross_cutting_lupa.py
@@ -4,13 +4,13 @@ import lupa
 import numpy as np
 from lukefi.metsi.data.enums.internal import TreeSpecies
 
-from lukefi.metsi.forestry.cross_cutting.cross_cutting import ZERO_DIAMETER_TREE_TIMBER_GRADE, ZERO_DIAMETER_TREE_VOLUME, \
-    ZERO_DIAMETER_TREE_VALUE
 from pathlib import Path
 
 CrossCutFn = Callable[..., tuple[Sequence[int], Sequence[float], Sequence[float]]]
 
+
 def cross_cut_lupa(P: np.ndarray) -> CrossCutFn:
+    """Produce a cross-cut wrapper function intialized with the crosscut.lua script using the Lupa bindings."""
     path = Path(__file__).parent.parent.resolve() / "lua" / "crosscut.lua"
 
     with open(path, "r") as file:
@@ -33,11 +33,6 @@ def cross_cut_lupa(P: np.ndarray) -> CrossCutFn:
             d: float,
             h: float
     ):
-        if d is not None and d < 0:
-            raise ValueError("breast_height_diameter must be a non-negative number")
-        if d in (None, 0):
-            return (np.array([ZERO_DIAMETER_TREE_TIMBER_GRADE]), np.array([ZERO_DIAMETER_TREE_VOLUME]), np.array([ZERO_DIAMETER_TREE_VALUE]))
-
         vol, val = aptfunc(spe, d, h)
         return list(map(int, np.unique(P[:, 0]))), list(vol.values()), list(val.values())
     return cc

--- a/lukefi/metsi/forestry/lua/crosscut.lua
+++ b/lukefi/metsi/forestry/lua/crosscut.lua
@@ -293,12 +293,19 @@ local function aptunpack(i, vol, val)
 	end
 end
 
-local function aptfunc(pcls, ptop, plen, pval, m, div, nas)
+local function aptfunc_fhk(pcls, ptop, plen, pval, m, div, nas)
 	return function(spe, d, h)
 		return aptunpack(1, apt(spe, d, h, pcls, ptop, plen, pval, m, div, nas))
 	end
 end
 
+local function aptfunc_lupa(pcls, ptop, plen, pval, m, div, nas)
+	return function(spe, d, h)
+		return apt(spe, d, h, pcls, ptop, plen, pval, m, div, nas)
+	end
+end
+
 return {
-	aptfunc = aptfunc
+	aptfunc_fhk = aptfunc_fhk,
+    aptfunc_lupa = aptfunc_lupa
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,8 @@ authors = [
     { name = "Urho Niemelä"}
 ]
 dependencies = [
-    "scipy==1.7.*",
+    "scipy==1.7.3",
+    "lupa==1.14.1",
     "lukefi.metsi.data @ https://github.com/lukefi/metsi-data/archive/refs/tags/1.0.0.zip",
     "fhk @ https://github.com/menu-hanke/fhk/releases/download/v4.0.0/fhk-4.0.0-cp310-cp310-win_amd64.whl ; platform_system=='Windows' and python_version=='3.10'",
     "fhk @ https://github.com/menu-hanke/fhk/releases/download/v4.0.0/fhk-4.0.0-cp311-cp311-win_amd64.whl ; platform_system=='Windows' and python_version=='3.11'",

--- a/tests/cross_cutting_test.py
+++ b/tests/cross_cutting_test.py
@@ -53,10 +53,10 @@ class CrossCuttingTest(TestCaseExtension):
         _, vol_fhk, val_fhk = cross_cut_fhk(DEFAULT_TIMBER_PRICE_TABLE)(species, breast_height_diameter, height)
         _, vol_py, val_py = cross_cutting.cross_cut(species, breast_height_diameter, height, DEFAULT_TIMBER_PRICE_TABLE)
         vol_r, val_r = self._cross_cut_with_r(species, breast_height_diameter, height, DEFAULT_TIMBER_PRICE_TABLE)
-        self.assertTrue(np.allclose(vol_lupa, np.array(vol_r), atol=10e-2))
+        self.assertTrue(np.allclose(vol_lupa, np.array(vol_r), atol=10e-6))
         self.assertTrue(np.allclose(vol_fhk, np.array(vol_r), atol=10e-6))
         self.assertTrue(np.allclose(vol_py, np.array(vol_r), atol=10e-6))
-        self.assertTrue(np.allclose(val_lupa, np.array(val_r), atol=10e-2))
+        self.assertTrue(np.allclose(val_lupa, np.array(val_r), atol=10e-6))
         self.assertTrue(np.allclose(val_fhk, np.array(val_r), atol=10e-6))
         self.assertTrue(np.allclose(val_py, np.array(val_r), atol=10e-6))
 

--- a/tests/cross_cutting_test.py
+++ b/tests/cross_cutting_test.py
@@ -8,9 +8,8 @@ from parameterized import parameterized
 
 
 from lukefi.metsi.forestry.cross_cutting import cross_cutting
-from lukefi.metsi.forestry.cross_cutting.cross_cutting import (
-    ZERO_DIAMETER_TREE_TIMBER_GRADE, ZERO_DIAMETER_TREE_VALUE,
-    ZERO_DIAMETER_TREE_VOLUME)
+from lukefi.metsi.forestry.cross_cutting.cross_cutting import ZERO_DIAMETER_DEFAULTS
+
 from tests.test_util import DEFAULT_TIMBER_PRICE_TABLE, TestCaseExtension
 from lukefi.metsi.forestry.cross_cutting.cross_cutting_lupa import cross_cut_lupa
 
@@ -65,7 +64,7 @@ class CrossCuttingTest(TestCaseExtension):
         for dbh in [0, None]:
             unique_timber_grades, volumes, values = cross_cutting.cross_cut(TreeSpecies.PINE, dbh, 10, DEFAULT_TIMBER_PRICE_TABLE)
             self.assertTrue(len(unique_timber_grades) == len(volumes) == len(values) == 1)
-            self.assertEqual(unique_timber_grades[0], ZERO_DIAMETER_TREE_TIMBER_GRADE)
-            self.assertEqual(volumes[0], ZERO_DIAMETER_TREE_VOLUME)
-            self.assertEqual(values[0], ZERO_DIAMETER_TREE_VALUE)
+            self.assertEqual(unique_timber_grades[0], ZERO_DIAMETER_DEFAULTS[0][0])
+            self.assertEqual(volumes[0], ZERO_DIAMETER_DEFAULTS[1][0])
+            self.assertEqual(values[0], ZERO_DIAMETER_DEFAULTS[2][0])
         self.assertRaises(ValueError, cross_cutting.cross_cut, *(TreeSpecies.PINE, -1, 10, DEFAULT_TIMBER_PRICE_TABLE))

--- a/tests/cross_cutting_test.py
+++ b/tests/cross_cutting_test.py
@@ -16,7 +16,7 @@ from lukefi.metsi.forestry.cross_cutting.cross_cutting_lupa import cross_cut_lup
 
 unrunnable = False
 try:
-    from lukefi.metsi.forestry.cross_cutting.cross_cutting_fhk import cross_cut_func
+    from lukefi.metsi.forestry.cross_cutting.cross_cutting_fhk import cross_cut_fhk
     import rpy2.robjects as robjects
     import lukefi.metsi.forestry.r_utils as r_utils
 except ImportError:
@@ -51,7 +51,7 @@ class CrossCuttingTest(TestCaseExtension):
     ])
     def test_implementation_equality(self, species, breast_height_diameter, height):
         _, vol_lupa, val_lupa = cross_cut_lupa(DEFAULT_TIMBER_PRICE_TABLE)(species, breast_height_diameter, height)
-        _, vol_fhk, val_fhk = cross_cut_func(DEFAULT_TIMBER_PRICE_TABLE)(species, breast_height_diameter, height)
+        _, vol_fhk, val_fhk = cross_cut_fhk(DEFAULT_TIMBER_PRICE_TABLE)(species, breast_height_diameter, height)
         _, vol_py, val_py = cross_cutting.cross_cut(species, breast_height_diameter, height, DEFAULT_TIMBER_PRICE_TABLE)
         vol_r, val_r = self._cross_cut_with_r(species, breast_height_diameter, height, DEFAULT_TIMBER_PRICE_TABLE)
         self.assertTrue(np.allclose(vol_lupa, np.array(vol_r), atol=10e-2))

--- a/tests/cross_cutting_test.py
+++ b/tests/cross_cutting_test.py
@@ -1,15 +1,10 @@
 from typing import Dict
 import unittest
-
 import numpy as np
-
 from lukefi.metsi.data.enums.internal import TreeSpecies
 from parameterized import parameterized
-
-from lukefi.metsi.forestry.cross_cutting.cross_cutting import ZERO_DIAMETER_DEFAULTS, cross_cut_py, cross_cut, _cross_cut_species_mapper
-
+from lukefi.metsi.forestry.cross_cutting.cross_cutting import ZERO_DIAMETER_DEFAULTS, cross_cut, _cross_cut_species_mapper
 from tests.test_util import DEFAULT_TIMBER_PRICE_TABLE, TestCaseExtension
-from lukefi.metsi.forestry.cross_cutting.cross_cutting_lupa import cross_cut_lupa
 
 unrunnable = False
 try:
@@ -47,9 +42,10 @@ class CrossCuttingTest(TestCaseExtension):
         (TreeSpecies.SPRUCE, 17.721245087039236, 16.353742669109522)
     ])
     def test_implementation_equality(self, species, breast_height_diameter, height):
-        _, vol_lupa, val_lupa = cross_cut_lupa(DEFAULT_TIMBER_PRICE_TABLE)(species, breast_height_diameter, height)
-        _, vol_fhk, val_fhk = cross_cut_fhk(DEFAULT_TIMBER_PRICE_TABLE)(species, breast_height_diameter, height)
-        _, vol_py, val_py = cross_cut_py(DEFAULT_TIMBER_PRICE_TABLE)(species, breast_height_diameter, height)
+        P = DEFAULT_TIMBER_PRICE_TABLE
+        _, vol_lupa, val_lupa = cross_cut(species, breast_height_diameter, height, P, 10, "lupa")
+        _, vol_fhk, val_fhk = cross_cut(species, breast_height_diameter, height, P, 10, "fhk")
+        _, vol_py, val_py = cross_cut(species, breast_height_diameter, height, P, 10, "py")
         vol_r, val_r = self._cross_cut_with_r(species, breast_height_diameter, height, DEFAULT_TIMBER_PRICE_TABLE)
         self.assertTrue(np.allclose(vol_lupa, np.array(vol_r), atol=10e-6))
         self.assertTrue(np.allclose(vol_fhk, np.array(vol_r), atol=10e-6))


### PR DESCRIPTION
As suggested, I made an implementation using Lupa as the Lua binding. Pretty straightforward. I also harmonized the interfaces between the now 3 different implementations.

I did find a strange problem between the FHK and the Lupa results. For our test cases:
        (TreeSpecies.PINE,30,25),
        (TreeSpecies.UNKNOWN_CONIFEROUS, 15.57254199723247, 18.293846547993535),
        (TreeSpecies.SPRUCE, 17.721245087039236, 16.353742669109522)
in the new combined result comparison test case `test_implementation_equality`, Only the PINE case produces same results between the Lupa and the FHK implementation. The other cases are similar but up to 10e-2 precision.

I traced it as far as being able to tell that this call begins to produce different results.
`local b1, b2, b3 = cpoly3(crkkd(spe, d, h))`

For PINE, both implementations create 
0.3790726638916	-0.96317648725111	0.60220515386963

For the two other cases,
fhk:
0.28608576496867	-0.68717880456732	0.41033970264433
0.22259277687883	-0.30344213700482	0.062352032624087

lupa:
0.31764687968092	-0.76211709836092	0.4546401343752
0.19007517785217	-0.25073591970627	0.043934752942561

Lupa uses Lua 5.4

@taplem do you have some idea what might be behind it? How to debug this further? Do you think it can be a Lua version difference?